### PR TITLE
Add experimental workflow for .next directory handling test

### DIFF
--- a/.github/workflows/test-next-handling.yml
+++ b/.github/workflows/test-next-handling.yml
@@ -1,0 +1,166 @@
+# Location: .github/workflows/test-next-handling.yml
+# This is a SAFE test that doesn't affect production
+
+name: Test .next Directory Handling
+
+on:
+  # Manual trigger only - completely safe
+  workflow_dispatch:
+    inputs:
+      test_description:
+        description: 'Test description (optional)'
+        required: false
+        default: 'Testing .next directory preservation'
+
+jobs:
+  test-next-preservation:
+    name: Test .next Directory Preservation
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Test Information
+        run: |
+          echo "🧪 EXPERIMENTAL TEST WORKFLOW"
+          echo "================================"
+          echo "Testing if .next directory can be preserved without renaming"
+          echo "Test description: ${{ github.event.inputs.test_description }}"
+          echo "This test does NOT affect production!"
+          echo ""
+      
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      
+      - name: Install dependencies
+        run: npm ci
+      
+      - name: Build project
+        run: |
+          echo "🏗️ Building project..."
+          npm run build
+          
+          echo "✅ Build complete"
+          echo "📊 Checking .next directory:"
+          if [ -d ".next" ]; then
+            echo "✅ .next directory exists"
+            echo "Size: $(du -sh .next | cut -f1)"
+            echo "Structure:"
+            ls -la .next/ | head -10
+          else
+            echo "❌ .next directory NOT found!"
+            exit 1
+          fi
+      
+      - name: Create test artifact WITHOUT renaming
+        run: |
+          echo "📦 Creating test package WITHOUT .next rename..."
+          
+          mkdir -p test-package
+          
+          # Copy .next directly without renaming
+          echo "Copying .next as-is..."
+          cp -r .next test-package/
+          
+          # Copy minimal other files for testing
+          cp package.json test-package/
+          cp package-lock.json test-package/
+          cp next.config.mjs test-package/
+          
+          echo "📋 Package contents:"
+          ls -la test-package/
+          
+          # Verify .next is really there
+          if [ -d "test-package/.next" ]; then
+            echo "✅ SUCCESS: .next exists in package without renaming!"
+            echo ".next size in package: $(du -sh test-package/.next | cut -f1)"
+          else
+            echo "❌ FAIL: .next missing from package"
+            exit 1
+          fi
+      
+      - name: Upload test artifact with hidden files flag
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-artifact-${{ github.run_id }}
+          path: test-package/
+          retention-days: 1  # Short retention for test
+          include-hidden-files: true  # Critical flag!
+      
+      - name: Clear workspace to simulate fresh environment
+        run: |
+          echo "🧹 Clearing workspace to simulate deployment environment..."
+          rm -rf test-package
+          rm -rf .next
+          ls -la
+      
+      # Now download and verify the artifact
+      - name: Download test artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: test-artifact-${{ github.run_id }}
+          path: downloaded-package
+      
+      - name: Verify downloaded artifact integrity
+        run: |
+          echo "🔍 CRITICAL TEST: Verifying downloaded artifact..."
+          echo "================================================="
+          
+          echo "📋 Downloaded contents:"
+          ls -la downloaded-package/
+          
+          # The moment of truth - is .next there?
+          if [ -d "downloaded-package/.next" ]; then
+            echo "✅✅✅ SUCCESS! .next directory preserved through artifact!"
+            echo ""
+            echo "Verification details:"
+            echo "- .next exists: YES"
+            echo "- Size: $(du -sh downloaded-package/.next | cut -f1)"
+            
+            # Check critical subdirectories
+            if [ -d "downloaded-package/.next/static" ]; then
+              echo "- .next/static exists: YES ✅"
+            else
+              echo "- .next/static exists: NO ❌"
+              exit 1
+            fi
+            
+            if [ -d "downloaded-package/.next/server" ]; then
+              echo "- .next/server exists: YES ✅"
+            else
+              echo "- .next/server exists: NO ❌"
+              exit 1
+            fi
+            
+            echo ""
+            echo "🎉 TEST PASSED! We can safely remove the rename workaround!"
+            echo "The include-hidden-files flag works correctly."
+            
+          else
+            echo "❌❌❌ FAIL: .next directory NOT preserved!"
+            echo "The rename workaround is still necessary."
+            echo ""
+            echo "Debugging info - what IS in the package:"
+            find downloaded-package -type d -maxdepth 2
+            exit 1
+          fi
+      
+      - name: Test Summary
+        if: always()
+        run: |
+          echo ""
+          echo "📊 TEST SUMMARY"
+          echo "==============="
+          if [ -d "downloaded-package/.next" ]; then
+            echo "✅ Result: SUCCESS"
+            echo "✅ Conclusion: We can remove the .next → next-build rename"
+            echo "✅ Next step: Update main CI/CD to work without renaming"
+          else
+            echo "❌ Result: FAILURE" 
+            echo "❌ Conclusion: The rename workaround is still needed"
+            echo "❌ Action required: Investigate why include-hidden-files doesn't work"
+          fi


### PR DESCRIPTION
## DO NOT MERGE YET - This is a test PR

This PR adds an experimental workflow to test if we can safely remove the `.next` → `next-build` rename workaround.

The workflow:
- Does NOT affect production
- Runs only manually
- Tests if `include-hidden-files: true` properly preserves the .next directory

### Test Plan:
1. Create PR (this one)
2. Run the test workflow manually
3. If test passes → we can remove rename logic from main pipeline
4. If test fails → we keep the rename workaround

After testing, we'll decide whether to merge this workflow or close the PR.