### PR TITLE
fix: add PORTFOLIO_TITLE to build env and replace hardcoded domains

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,7 @@ jobs:
       
       - name: Build project
         env:
+          PORTFOLIO_TITLE: ${{ secrets.PORTFOLIO_TITLE }}
           NEXT_PUBLIC_WEB3_SHARED_ACCESS_CODE: ${{ secrets.NEXT_PUBLIC_WEB3_SHARED_ACCESS_CODE }}
         run: |
           echo "🏗️ Building project..."
@@ -149,7 +150,6 @@ jobs:
           echo "  Static assets: $(du -sh .next/static | cut -f1)"
           echo "  Server bundles: $(du -sh .next/server | cut -f1)"
       
-      # FOR PULL REQUESTS: Create lightweight verification report
       - name: Create PR verification artifact
         if: github.event_name == 'pull_request'
         run: |
@@ -180,7 +180,6 @@ jobs:
           retention-days: 2
           compression-level: 6
       
-      # FOR MAIN BRANCH: Create staging deployment package
       - name: Prepare staging deployment package
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
@@ -221,14 +220,13 @@ jobs:
           echo "  ✅ next.config.mjs"
           echo "  ❌ src/ (NOT included - not needed in production)"
       
-      # Upload staging deployment artifact (14 days retention)
       - name: Upload staging deployment artifact
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@v4
         with:
           name: staging-package-${{ github.sha }}
           path: deployment-package/
-          retention-days: 14  # Staging artifacts kept for 14 days
+          retention-days: 14  
           compression-level: 6
           include-hidden-files: true
       
@@ -239,5 +237,5 @@ jobs:
           echo ""
           echo "Next steps:"
           echo "- Staging deployment will be triggered automatically"
-          echo "- Test your changes at: https://stage.undevy.com"
+          echo "- Test your changes at: https://${{ secrets.STAGING_DOMAIN_1 }}"
           echo "- When ready for production, run: npm run release"

--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -7,7 +7,7 @@ name: Deploy Production Release
 on:
   push:
     tags:
-      - 'v*.*.*'  # Semantic versioning tags only
+      - 'v*.*.*'
 
 jobs:
   build-and-deploy-production:
@@ -20,12 +20,13 @@ jobs:
           echo "🏷️ Production Release Deployment"
           echo "Tag: ${{ github.ref_name }}"
           echo "Commit: ${{ github.sha }}"
-          echo "Target: undevy.com / foxous.design"
+          # CHANGE: Using secrets for domain names instead of hardcoding
+          echo "Target: ${{ secrets.PRODUCTION_DOMAIN_1 }} / ${{ secrets.PRODUCTION_DOMAIN_2 }}"
       
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # Need full history for changelog
+          fetch-depth: 0 
       
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -41,9 +42,10 @@ jobs:
       - name: Build production release
         env:
           NODE_ENV: production
+          PORTFOLIO_TITLE: ${{ secrets.PORTFOLIO_TITLE }}
           NEXT_PUBLIC_WEB3_SHARED_ACCESS_CODE: ${{ secrets.NEXT_PUBLIC_WEB3_SHARED_ACCESS_CODE }}
         run: |
-          echo "🏗️ Building production release ${{ github.ref_name }}..."
+          echo "🗏 Building production release ${{ github.ref_name }}..."
           
           # Clean build for production
           rm -rf .next
@@ -94,7 +96,6 @@ jobs:
           echo "✅ Release package created"
           echo "📊 Package size: $(du -h portfolio-release-${{ github.ref_name }}.tar.gz | cut -f1)"
       
-      # Upload release artifact to GitHub Release (permanent storage)
       - name: Upload release artifact to GitHub Release
         uses: softprops/action-gh-release@v1
         with:
@@ -239,8 +240,9 @@ jobs:
             echo ""
             echo "🎉 Release $RELEASE_TAG is now live!"
             echo "🌐 Sites:"
-            echo "  - https://undevy.com"
-            echo "  - https://foxous.design"
+            # CHANGE: Using secrets for domain names instead of hardcoding
+            echo "  - https://${{ secrets.PRODUCTION_DOMAIN_1 }}"
+            echo "  - https://${{ secrets.PRODUCTION_DOMAIN_2 }}"
             if [ -n "$PREVIOUS_VERSION" ]; then
               echo ""
               echo "🔄 Rollback command (if needed):"
@@ -256,8 +258,9 @@ jobs:
           echo "Commit: ${{ github.sha }}"
           echo ""
           echo "Production sites updated:"
-          echo "  🌐 https://undevy.com"
-          echo "  🌐 https://foxous.design"
+          # CHANGE: Using secrets for domain names instead of hardcoding
+          echo "  🌐 https://${{ secrets.PRODUCTION_DOMAIN_1 }}"
+          echo "  🌐 https://${{ secrets.PRODUCTION_DOMAIN_2 }}"
           echo ""
           echo "Release artifact permanently stored in GitHub Releases"
           echo "Blue-green deployment completed with rollback capability"

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -23,7 +23,7 @@ jobs:
           echo "Commit: ${{ github.event.workflow_run.head_sha }}"
           echo "Triggered by: ${{ github.event.workflow_run.name }}"
           echo "Run ID: ${{ github.event.workflow_run.id }}"
-          echo "Target: stage.undevy.com / stage.foxous.design"
+          echo "Target: ${{ secrets.STAGING_DOMAIN_1 }} / ${{ secrets.STAGING_DOMAIN_2 }}"
       
       - name: Download staging artifact
         uses: dawidd6/action-download-artifact@v6
@@ -169,8 +169,8 @@ jobs:
             echo "✅ Staging deployment completed!"
             echo ""
             echo "🌐 Access staging at:"
-            echo "  - https://stage.undevy.com"
-            echo "  - https://stage.foxous.design"
+            echo "  - https://${{ secrets.STAGING_DOMAIN_1 }}"
+            echo "  - https://${{ secrets.STAGING_DOMAIN_2 }}"
       
       - name: Deployment summary
         run: |
@@ -179,13 +179,12 @@ jobs:
           echo "Commit: ${{ github.event.workflow_run.head_sha }}"
           echo ""
           echo "Staging sites are now live at:"
-          echo "  🌐 https://stage.undevy.com"
-          echo "  🌐 https://stage.foxous.design"
+          echo "  🌐 https://${{ secrets.STAGING_DOMAIN_1 }}"
+          echo "  🌐 https://${{ secrets.STAGING_DOMAIN_2 }}"
           echo ""
           echo "Note: Staging will auto-shutdown after 2 hours of inactivity"
           echo "To promote to production, run: npm run release"
   
-  # Handle failed CI
   failure-notification:
     name: Handle CI Failure
     runs-on: ubuntu-latest


### PR DESCRIPTION
- Added PORTFOLIO_TITLE environment variable to CI and Release builds
- Replaced hardcoded domain names with GitHub secrets
- This ensures proper portfolio title is baked into builds
- Improves security by not exposing domain names in public code